### PR TITLE
fix(dotnet install): Download correct godot asset from GitHub for DotNet on linux, and find executable in sub-folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "walkdir",
  "which",
  "zip",
 ]
@@ -1369,6 +1370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1784,6 +1794,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,6 +1941,15 @@ dependencies = [
  "home",
  "rustix 0.38.44",
  "winsafe",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Cross-platform process management
 which = "6.0"
+
+# Cross-platform recursive directory navigation
+walkdir = "2.5.0"

--- a/src/github.rs
+++ b/src/github.rs
@@ -32,10 +32,10 @@ impl GitHubRelease {
             ("windows", "x86_64") => vec!["win64"],
             ("windows", "x86") => vec!["win32", "win64"], // Fallback to 64-bit if 32-bit not available
             ("macos", _) => vec!["macos"],                // macOS universal binaries
-            ("linux", "x86_64") => vec!["linux.x86_64", "linux"], // Prefer specific, fallback to generic
-            ("linux", "x86") => vec!["linux.x86_32", "linux.x86_64", "linux"],
-            ("linux", "arm") => vec!["linux.arm32", "linux.arm64", "linux"], // ARM32 preferred, but ARM64 compatible
-            ("linux", "aarch64") => vec!["linux.arm64", "linux.x86_64", "linux"], // ARM64 preferred
+            ("linux", "x86_64") => vec!["linux.x86_64", "linux_x86_64", "linux"], // Prefer specific, fallback to generic
+            ("linux", "x86") => vec!["linux.x86_32", "linux_x86_32", "linux.x86_64", "linux_x86_64", "linux"],
+            ("linux", "arm") => vec!["linux.arm32", "linux_arm32", "linux.arm64", "linux_arm64", "linux"], // ARM32 preferred, but ARM64 compatible
+            ("linux", "aarch64") => vec!["linux.arm64", "linux_arm64", "linux.x86_64", "linux_x86_64", "linux"], // ARM64 preferred
             // Fallbacks
             ("windows", _) => vec!["win64", "win32"],
             ("linux", _) => vec!["linux.x86_64", "linux"],
@@ -214,7 +214,7 @@ mod tests {
                 size: 1000,
             },
             GitHubAsset {
-                name: "Godot_v4.2.1-stable_mono_linux.x86_64.zip".to_string(),
+                name: "Godot_v4.2.1-stable_mono_linux_x86_64.zip".to_string(),
                 browser_download_url: "https://example.com/mono-linux".to_string(),
                 size: 1000,
             },


### PR DESCRIPTION
This PR fixes two issues:

1. `gdenv install 4.5 --dotnet` would download `Godot_v4.5-stable_mono_linux_arm32.zip` on a linux x86_64 platform. This happens because the DotNet assets on GitHub use an underscore between linux and x86_64: `
Godot_v4.2.1-stable_mono_linux_x86_64.zip`.

2. `gdenv use 4.5 --dotnet` would fail to find the Godot executable because the extracted GitHub asset for DotNet is contained in a sub-folder.

Fixes https://github.com/bytemeadow/gdenv/issues/7