### PR TITLE
fix(gdenv editor command): Improvements to `gdenv editor` CLI command

### DIFF
--- a/gdenv-lib/src/api/godot_runner.rs
+++ b/gdenv-lib/src/api/godot_runner.rs
@@ -124,7 +124,13 @@ impl<D: DownloadClient> GodotRunner<D> {
 
         let mut command_chain = CommandChain::new();
 
-        if self.pre_import && !project_spec.godot_project_dir.join(".godot").exists() {
+        if self.pre_import
+            && project_spec
+                .godot_project_dir
+                .join("project.godot")
+                .exists()
+            && !project_spec.godot_project_dir.join(".godot").exists()
+        {
             let failure_message = "Possible cause: Known bug in Godot 4.5.1: \"Headless import of project with GDExtensions crashes\"\n\
                 See: https://github.com/godotengine/godot/issues/111645\n\
                 Try re-running if `.godot` folder was generated successfully.";

--- a/gdenv-lib/src/api/godot_runner.rs
+++ b/gdenv-lib/src/api/godot_runner.rs
@@ -66,6 +66,7 @@ impl<D: DownloadClient> GodotRunner<D> {
             |error| -> Result<ProjectSpecification> {
                 match error {
                     ProjectSpecError::NotFound => Ok(ProjectSpecification {
+                        spec_file_path: None,
                         godot_version: self.godot_version.clone().context(
                             "No Godot version specified and no configuration file found.",
                         )?,
@@ -80,7 +81,16 @@ impl<D: DownloadClient> GodotRunner<D> {
                 }
             },
         )?;
+
+        // Use the project spec root as the working directory when available.
+        let project_working_dir = spec_from_file
+            .spec_file_path
+            .as_deref()
+            .and_then(|path| path.parent())
+            .unwrap_or(working_dir);
+
         let project_spec = ProjectSpecification {
+            spec_file_path: spec_from_file.spec_file_path.clone(),
             godot_version: self
                 .godot_version
                 .clone()
@@ -93,13 +103,13 @@ impl<D: DownloadClient> GodotRunner<D> {
                 .godot_project_path
                 .clone()
                 .unwrap_or(spec_from_file.godot_project_dir)
-                .to_absolute(working_dir)?,
+                .to_absolute(project_working_dir)?,
             ..spec_from_file
         };
 
         for (name, generator) in project_spec.gdextension {
             generator
-                .build(working_dir)
+                .build(project_working_dir)
                 .context(format!("Failed to build GDExtension file: {}", name))?
                 .write()?;
         }
@@ -223,9 +233,45 @@ mod tests {
     use anyhow::Result;
     use std::fs;
     use std::path::Path;
+    use tempfile::TempDir;
 
     #[tokio::test]
-    async fn test_create() -> Result<()> {
+    async fn test_create_from_project_root() -> Result<()> {
+        let (tmp_dir, project_dir, godot_project_dir, config, runner) = initialize_project()?;
+        let command_chain = runner.build_at(&project_dir).await?;
+        verify_project(
+            tmp_dir,
+            project_dir,
+            godot_project_dir,
+            &config,
+            command_chain,
+        )?;
+        Ok(())
+    }
+
+    /// Verify that running gdenv from a subdirectory within a gdenv.toml project uses
+    /// gdenv.toml's location as the working directory.
+    #[tokio::test]
+    async fn test_create_from_sub_directory() -> Result<()> {
+        let (tmp_dir, project_dir, godot_project_dir, config, runner) = initialize_project()?;
+        let command_chain = runner.build_at(&godot_project_dir).await?;
+        verify_project(
+            tmp_dir,
+            project_dir,
+            godot_project_dir,
+            &config,
+            command_chain,
+        )?;
+        Ok(())
+    }
+
+    fn initialize_project() -> Result<(
+        TempDir,
+        PathBuf,
+        PathBuf,
+        Config,
+        GodotRunner<MockDownloadClient>,
+    )> {
         let tmp_dir = tempfile::Builder::new().prefix("gdenv-lib").tempdir()?;
         let data_dir = tmp_dir.path().join("data");
         let project_dir = tmp_dir.path().join("project");
@@ -238,9 +284,16 @@ mod tests {
         let runner = GodotRunner::default()
             .config(Some(config.clone()))
             .download_client(Some(MockDownloadClient));
+        Ok((tmp_dir, project_dir, godot_project_dir, config, runner))
+    }
 
-        let command_chain = runner.build_at(&project_dir).await?;
-
+    fn verify_project(
+        _tmp_dir: TempDir,
+        _project_dir: PathBuf,
+        godot_project_dir: PathBuf,
+        config: &Config,
+        command_chain: CommandChain,
+    ) -> Result<()> {
         assert_eq!(command_chain.commands().len(), 2);
         assert_eq!(
             command_chain.commands()[0].executable.canonicalize()?,

--- a/gdenv-lib/src/command_runner.rs
+++ b/gdenv-lib/src/command_runner.rs
@@ -20,10 +20,17 @@ pub struct CommandChain {
 impl Command {
     fn execute(&self) -> Result<()> {
         let mut command = std::process::Command::new(&self.executable);
+        command.current_dir(&self.working_dir).args(&self.args);
+
+        if !self.working_dir.exists() {
+            bail!(
+                "Can't execute command: {:?}\n    Reason: Working directory does not exist: {:?}",
+                command,
+                self.working_dir
+            );
+        }
 
         let status = command
-            .current_dir(&self.working_dir)
-            .args(&self.args)
             .spawn()
             .with_context(|| format!("Failed to spawn process: {:?}", command))?
             .wait()

--- a/gdenv-lib/src/project_specification.rs
+++ b/gdenv-lib/src/project_specification.rs
@@ -26,6 +26,8 @@ pub enum ProjectSpecError {
 /// Godot configuration project specification
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct ProjectSpecification {
+    /// Path to the project specification file.
+    pub spec_file_path: Option<PathBuf>,
     /// Godot version to use when running the project.
     pub godot_version: GodotVersion,
     /// Path to the Godot project directory.
@@ -254,6 +256,7 @@ pub fn load_godot_project_spec<P: CargoInfoProvider>(
             ))?;
             let project_dir = spec.godot.project_dir.unwrap_or(PathBuf::from("."));
             Ok(ProjectSpecification {
+                spec_file_path: Some(path.clone()),
                 godot_version: GodotVersion::new(
                     &spec.godot.version,
                     spec.godot.dotnet.unwrap_or(false),
@@ -263,7 +266,7 @@ pub fn load_godot_project_spec<P: CargoInfoProvider>(
                 editor_args: spec.godot.editor_args.unwrap_or_default(),
                 pre_import: spec.godot.pre_import.unwrap_or(true),
                 gdextension: gdextension_generator_to_config(
-                    start_path,
+                    path.parent().unwrap_or(start_path),
                     spec.gdextension.unwrap_or_default(),
                     &project_dir,
                     cargo_target_path_provider,
@@ -272,13 +275,14 @@ pub fn load_godot_project_spec<P: CargoInfoProvider>(
             })
         }
         SpecFileType::Version(path) => {
-            let file_content = fs::read_to_string(path)?;
+            let file_content = fs::read_to_string(&path)?;
             let mut version_str = file_content.trim().split(' ');
             let version = version_str
                 .next()
                 .context("No version specified in .godot-version file.")?;
             let dotnet = version_str.next().unwrap_or("");
             Ok(ProjectSpecification {
+                spec_file_path: Some(path),
                 godot_version: GodotVersion::new(version, dotnet == "dotnet" || dotnet == "mono")?,
                 godot_project_dir: PathBuf::from("."),
                 run_args: vec![],
@@ -409,13 +413,14 @@ include = ["addons/gdUnit4"]
 [addon.local-project]
 path = "../local-project"
         "#;
-        fs::write(version_file, str_spec)?;
+        fs::write(&version_file, str_spec)?;
         let cargo_info = CargoInfo {
             crate_name: "my_gdextension".to_string(),
             target_dir: PathBuf::from("/home/user/.cache/cargo/target"),
         };
         let spec = load_godot_project_spec(tmp_dir.path(), |_| Ok(cargo_info.clone()))?;
         let expected_spec = ProjectSpecification {
+            spec_file_path: Some(version_file),
             godot_version: GodotVersion::new("4.6.0", true)?,
             godot_project_dir: PathBuf::from("./godot"),
             run_args: vec!["arg1".to_string(), "arg2".to_string()],


### PR DESCRIPTION
This fixes several issues with the `gdenv editor` command.
- You can now run `gdenv editor` from within a subdirectory of a gdenv.toml project.
- Will no longer try to pre-import a Godot project if the `project.godot` file doesn't exist. This allows the Godot editor to open in project management mode so you can create a new empty Godot project.
- Improved the error message when working directory does not exist.
